### PR TITLE
fix: tag notebook autosave with sandbox id (PS-586)

### DIFF
--- a/notebookUtils.py
+++ b/notebookUtils.py
@@ -45,7 +45,7 @@ def saveFile(file_path, token, log):
     else:
         url = 'http://data-loader-api/data-loader-api/save'
     headers = {'X-StorageApi-Token': token, 'User-Agent': 'Keboola Sandbox Autosave Request'}
-    payload = {'file': {'source': file_path, 'tags': ['autosave']}}
+    payload = {'file': {'source': file_path, 'tags': ['autosave', 'sandbox-' + os.environ['SANDBOX_ID']]}}
 
     # the timeout is set to > 3min because of the delay on 400 level exception responses
     # https://keboola.atlassian.net/browse/PS-186


### PR DESCRIPTION
I haven’t realized that during the restore task, the component should get the notebook from the terminated sandbox automatically. 🙄  But the file in Storage has just tags `autosave` and `jupyter_workspace` so it is not possible to identify to what sandbox it belongs.