### PR TITLE
Save gzip on git compress to data folder (PS-1994)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='1.2.1',
+    version='1.2.2',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},


### PR DESCRIPTION
So the gzip is stored in /data folder and removed after the upload.

And I simplified the code a little. I believe that the `saveNotebook` function (https://github.com/keboola/sandboxes-notebook-utils/blob/master/notebookUtils.py#L116-L136) was more or less redundant. I realized that after I removed the compressing logic from `saveFolder` to `compressFolder` (so that the compression can be tested). Does it make sense? 🙂