### PR TITLE
Switch expiration ping to API from put to patch

### DIFF
--- a/notebookUtils.py
+++ b/notebookUtils.py
@@ -91,7 +91,7 @@ def updateApiTimestamp(sandbox_id, token, log):
     }
     url = os.environ['SANDBOXES_API_URL'] + '/sandboxes/' + sandbox_id
     body = json.dumps({'lastAutosaveTimestamp': datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')})
-    result = retrySession().put(url, data=body, headers=headers)
+    result = retrySession().patch(url, data=body, headers=headers)
     if result.status_code == requests.codes.ok:
         log.info('Successfully saved autosave to Sandboxes API')
     else:

--- a/tests/notebookUtils.py
+++ b/tests/notebookUtils.py
@@ -41,7 +41,7 @@ class TestNotebookUtils():
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
             os.environ['KBC_TOKEN'] = 'token'
             dataLoaderMock = m.post('http://dataloader/data-loader-api/save', json={'result': 'ok'})
-            apiMock = m.put('http://sandboxes-api/sandboxes/123', json={'result': 'ok'})
+            apiMock = m.patch('http://sandboxes-api/sandboxes/123', json={'result': 'ok'})
 
             contentsManager = type('', (), {})()
             contentsManager.log = logging
@@ -67,7 +67,7 @@ class TestNotebookUtils():
     def test_updateApiTimestamp(self):
         with requests_mock.Mocker() as m:
             os.environ['SANDBOXES_API_URL'] = 'http://sandboxes-api'
-            apiMock = m.put('http://sandboxes-api/sandboxes/123', json={'result': 'ok'})
+            apiMock = m.patch('http://sandboxes-api/sandboxes/123', json={'result': 'ok'})
 
             updateApiTimestamp('123', 'token', logging)
 


### PR DESCRIPTION
I just walked around. 🙂 (Patch is the right one because we are not replacing the whole db record. The API supports both for now: https://github.com/keboola/sandboxes-api/blob/9a5e670426285960f2c0ac9987158efefffe8a53/src/httpHandler.js#L90-L91)