### PR TITLE
AJDA-2169 - Switch autosave to data-loader internal endpoint 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/notebookUtils.py
+++ b/notebookUtils.py
@@ -128,34 +128,24 @@ def saveFolder(folder_path, sandbox_id, log):
                 os.remove(gz_path)
 
 
-def _get_internal_save_url():
-    """Get the URL for the internal save endpoint."""
-    base = os.environ.get('DATA_LOADER_API_URL', 'data-loader-api')
-    return f'http://{base}/data-loader-api/internal/save'
-
-
 def scriptPostSave(model, os_path, contents_manager, **kwargs):
     """
-    Hook on notebook save - delegates to data-loader-api internal endpoint.
+    Hook on notebook save
+    - Saves the notebook file to Keboola Storage
+    - Saves .git folder to Keboola Storage if initialized
+    - Updates lastAutosaveTimestamp in the API record
     """
     if model['type'] != 'notebook':
         return
-
     log = contents_manager.log
-    log.info(f'Notebook saved: {os_path}, triggering autosave')
 
-    url = _get_internal_save_url()
-    try:
-        response = retrySession().post(
-            url,
-            json={'file_path': os_path},
-            headers={'Content-Type': 'application/json'},
-            timeout=300,  # 5 min for large notebooks + git
-        )
-        response.raise_for_status()
-        log.info('Autosave completed successfully')
-    except Exception as e:
-        log.exception(f'Autosave failed: {e}')
+    sandbox_id = os.environ['SANDBOX_ID']
+    updateApiTimestamp(sandbox_id, log)
+
+    has_persistent_storage = os.getenv('HAS_PERSISTENT_STORAGE', 'False').lower() in ('true', '1')
+    if not has_persistent_storage:
+        saveFile(os_path, sandbox_id, log)
+        saveFolder('/data/.git', sandbox_id, log)
 
 
 def notebookSetup(c):

--- a/notebookUtils.py
+++ b/notebookUtils.py
@@ -128,10 +128,10 @@ def saveFolder(folder_path, sandbox_id, log):
                 os.remove(gz_path)
 
 
-def _get_internal_autosave_url():
-    """Get the URL for the internal autosave endpoint."""
+def _get_internal_save_url():
+    """Get the URL for the internal save endpoint."""
     base = os.environ.get('DATA_LOADER_API_URL', 'data-loader-api')
-    return f'http://{base}/data-loader-api/internal/autosave'
+    return f'http://{base}/data-loader-api/internal/save'
 
 
 def scriptPostSave(model, os_path, contents_manager, **kwargs):
@@ -144,7 +144,7 @@ def scriptPostSave(model, os_path, contents_manager, **kwargs):
     log = contents_manager.log
     log.info(f'Notebook saved: {os_path}, triggering autosave')
 
-    url = _get_internal_autosave_url()
+    url = _get_internal_save_url()
     try:
         response = retrySession().post(
             url,

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 Pygments==2.7.4
 pyparsing==2.4.7
-pytest==5.4.3
+pytest==6.2.5
 requests==2.25.1
 requests-mock==1.8.0
 six==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='2.2.0',
+    version='2.3.0.dev2',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='2.3.0.dev3',
+    version='2.3.0.dev4',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='2.3.0.dev4',
+    version='2.3.0.dev5',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='2.3.0.dev2',
+    version='2.3.0.dev3',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},
-    requires=['pip']
+    python_requires='>=3.10',
+    install_requires=['requests'],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='2.3.0.dev5',
+    version='2.3.0',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/tests/notebookUtils.py
+++ b/tests/notebookUtils.py
@@ -8,7 +8,7 @@ import string
 import tempfile
 
 from notebookUtils import compressFolder, notebookSetup, saveFile, saveFolder, \
-    scriptPostSave, updateApiTimestamp, _get_internal_autosave_url
+    scriptPostSave, updateApiTimestamp, _get_internal_save_url
 
 def generate_random_string():
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=5))
@@ -38,11 +38,11 @@ class TestNotebookUtils():
         assert "object has no attribute 'password'" in str(attribute_error.value)
 
     def test_scriptPostSave(self):
-        """Test that scriptPostSave calls the internal autosave endpoint."""
+        """Test that scriptPostSave calls the internal save endpoint."""
         with requests_mock.Mocker() as m:
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
 
-            autosaveMock = m.post('http://dataloader/data-loader-api/internal/autosave', json={'status': 'ok'})
+            autosaveMock = m.post('http://dataloader/data-loader-api/internal/save', json={'status': 'ok'})
 
             contentsManager = type('', (), {})()
             contentsManager.log = logging
@@ -57,7 +57,7 @@ class TestNotebookUtils():
         with requests_mock.Mocker() as m:
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
 
-            autosaveMock = m.post('http://dataloader/data-loader-api/internal/autosave', json={'status': 'ok'})
+            autosaveMock = m.post('http://dataloader/data-loader-api/internal/save', json={'status': 'ok'})
 
             contentsManager = type('', (), {})()
             contentsManager.log = logging
@@ -70,7 +70,7 @@ class TestNotebookUtils():
         with requests_mock.Mocker() as m:
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
 
-            autosaveMock = m.post('http://dataloader/data-loader-api/internal/autosave', status_code=500)
+            autosaveMock = m.post('http://dataloader/data-loader-api/internal/save', status_code=500)
 
             contentsManager = type('', (), {})()
             contentsManager.log = logging
@@ -79,18 +79,18 @@ class TestNotebookUtils():
 
             assert autosaveMock.call_count == 1
 
-    def test_get_internal_autosave_url_with_env(self):
+    def test_get_internal_save_url_with_env(self):
         """Test URL construction with DATA_LOADER_API_URL set."""
         os.environ['DATA_LOADER_API_URL'] = 'custom-api-host'
-        url = _get_internal_autosave_url()
-        assert url == 'http://custom-api-host/data-loader-api/internal/autosave'
+        url = _get_internal_save_url()
+        assert url == 'http://custom-api-host/data-loader-api/internal/save'
 
-    def test_get_internal_autosave_url_default(self):
+    def test_get_internal_save_url_default(self):
         """Test URL construction with default value."""
         if 'DATA_LOADER_API_URL' in os.environ:
             del os.environ['DATA_LOADER_API_URL']
-        url = _get_internal_autosave_url()
-        assert url == 'http://data-loader-api/data-loader-api/internal/autosave'
+        url = _get_internal_save_url()
+        assert url == 'http://data-loader-api/data-loader-api/internal/save'
 
     def test_updateApiTimestamp(self):
         with requests_mock.Mocker() as m:

--- a/tests/notebookUtils.py
+++ b/tests/notebookUtils.py
@@ -7,7 +7,7 @@ import requests_mock
 import string
 import tempfile
 
-from notebookUtils import compressFolder, getStorageTokenFromEnv, notebookSetup, saveFile, saveFolder, \
+from notebookUtils import compressFolder, notebookSetup, saveFile, saveFolder, \
     scriptPostSave, updateApiTimestamp, _get_internal_autosave_url
 
 def generate_random_string():
@@ -92,17 +92,6 @@ class TestNotebookUtils():
         url = _get_internal_autosave_url()
         assert url == 'http://data-loader-api/data-loader-api/internal/autosave'
 
-    def test_getStorageTokenFromEnvMissing(self):
-        if 'KBC_TOKEN' in os.environ:
-            del os.environ['KBC_TOKEN']
-        with pytest.raises(Exception):
-            getStorageTokenFromEnv(logging)
-
-    def test_getStorageTokenFromEnvOk(self):
-        token = generate_random_string()
-        os.environ['KBC_TOKEN'] = token
-        assert getStorageTokenFromEnv(logging) == token
-
     def test_updateApiTimestamp(self):
         with requests_mock.Mocker() as m:
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
@@ -116,9 +105,9 @@ class TestNotebookUtils():
     def test_saveFile(self):
         with requests_mock.Mocker() as m:
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
-            dataLoaderMock = m.post('http://dataloader/data-loader-api/save', json={'result': 'ok'})
+            dataLoaderMock = m.post('http://dataloader/data-loader-api/internal/save', json={'result': 'ok'})
 
-            saveFile('/file/path', '123', 'token', logging)
+            saveFile('/file/path', '123', logging)
 
             assert dataLoaderMock.call_count == 1
             response = json.loads(dataLoaderMock.last_request.text)
@@ -145,14 +134,14 @@ class TestNotebookUtils():
     def test_saveFolder(self):
         with requests_mock.Mocker() as m:
             os.environ['DATA_LOADER_API_URL'] = 'dataloader'
-            dataLoaderMock = m.post('http://dataloader/data-loader-api/save', json={'result': 'ok'})
+            dataLoaderMock = m.post('http://dataloader/data-loader-api/internal/save', json={'result': 'ok'})
 
             folder_prepare = tempfile.mkdtemp() + '/.git'
             os.mkdir(folder_prepare)
             f = open(folder_prepare + '/file.txt', 'a')
             f.write('content')
             f.close()
-            saveFolder(folder_prepare, '123', 'token', logging)
+            saveFolder(folder_prepare, '123', logging)
 
             assert dataLoaderMock.call_count == 1
             response = json.loads(dataLoaderMock.last_request.text)


### PR DESCRIPTION
## Release Notes

- Prepares notebook autosave to work without a Storage API token, as part of the broader effort to remove tokens from Jupyter sandbox containers
- Switches the autosave script to use the data-loader's internal save path, restricted to localhost only
- This release has **no user-facing effect on its own** — it only takes effect once new JupyterLab images are built with this package and distributed via runtimes
- Aligns minimum Python version (3.10) with what's actually running in Keboola Jupyter container images

## Change Type

**Minor**

## Impact Analysis

- **Who's affected:** Jupyter-type sandbox users and the autosave background process
- **Main value:** Removes the need to expose a Storage API token inside notebook containers
- **Risks:** Low — requires data-loader 4.3 (deployed via [sandboxes#575](https://github.com/keboola/sandboxes/pull/575)) to already be in place; the internal save endpoint must be available before new JupyterLab images are distributed

## Customer Communication Plans

No external communication needed. The user experience is identical — notebooks continue to autosave transparently.

## Justification

Jupyter sandbox containers currently require a Storage API token for notebook autosave, which is a security concern. This change is step 2 of a multi-phase effort to remove storage tokens from sandbox containers entirely, as part of the Sandbox API deprecation initiative.

## Deployment Plan

- Merge and release notebook-utils 2.3.0 
- Build new JupyterLab sandbox images for Python 3.10 containing the updated notebook-utils 
- Register the new images in Sandboxes runtimes

## Rollback Plan

Since this release has no effect on its own, no rollback is needed at this stage. If issues arise after step 3 (new JupyterLab images), rebuild the images with the previous notebook-utils version 2.2.0 to restore the original token-based autosave path. No data loss or service disruption expected.

## Post-Release Support Plan

- Watch for unexpected errors on the internal save path
- Confirm autosave continues to work correctly across all sandbox environments
