### PR TITLE
refactor: use data-loader-api internal endpoints, remove KBC_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='1.4.0.dev1',
+    version='1.4.0,
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='1.4.0,
+    version='1.4.0',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='1.3.2',
+    version='1.4.0.dev1',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},


### PR DESCRIPTION
## Summary
- Switch `saveFile()` and `updateApiTimestamp()` to use `/data-loader-api/internal/save` and `/data-loader-api/internal/activity` endpoints
- Remove `KBC_TOKEN` / `X-StorageApi-Token` dependency from autosave flow
- Remove `getStorageTokenFromEnv()` function
- Backport of 2.x data-loader changes to 1.3.2 base (version `1.4.0.dev1`)

## Test plan
- [x] All 6 existing tests pass with updated mocks
- [x] Lint clean (`flake8` critical errors)
- [x] Deploy to test sandbox environment and verify autosave works
  - `3.1.0-5ef6f07-utils-1.4.0.dev1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)