### PR TITLE
fix: lower python_requires to >=3.8 and add CI test matrix for Python…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.8', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from distutils.core import setup
 
 setup(
     name='keboola-sandboxes-notebook-utils',
-    version='2.3.0',
+    version='2.3.1',
     url='https://github.com/keboola/sandboxes-notebook-utils',
     packages=['keboola_notebook_utils'],
     package_dir={'keboola_notebook_utils': ''},
-    python_requires='>=3.10',
+    python_requires='>=3.8',
     install_requires=['requests'],
 )


### PR DESCRIPTION
… 3.8

Release notes https://linear.app/keboola/issue/AJDA-2293/sandboxes-jupyterlab-build-r-images-with-updated-notebook-utils#comment-4295764f